### PR TITLE
Fix scaling behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.4.1 (2025-12-05)
+- The new API implements a different scaling value behaviour. To preserve backwards compatibility, this new version 
+aligns with the old behaviour.
+
 ## v1.4.0 (2025-12-05)
 - The October 2025 release of WEO removed bulk downloads and moved everything towards the SDMX API. This update provides a way to parse new releases from the API instead of relying on the XML files. Note that thew new API response does not include observation-level notes or information on when projections start for each country-indicator.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "imf-reader"
-version = "1.4.0"
+version = "1.4.1"
 description = "A package to access imf data"
 authors = [{ name = "The ONE Campaign" }]
 license = { text = "MIT" }


### PR DESCRIPTION
This pull request releases version 1.4.1 of the `imf-reader` package, addressing a compatibility issue with the new API's scaling behavior. The update ensures that values and scale codes are processed to match the legacy format, preserving backward compatibility for users relying on the old data structure.

**Changelog and Versioning:**

* Updated `CHANGELOG.md` to document the new scaling value behavior and the compatibility fix.
* Bumped the package version to `1.4.1` in `pyproject.toml`.

**API Data Handling and Compatibility:**

* Introduced the `SCALE_MULTIPLIERS` mapping in `src/imf_reader/weo/api.py` to convert scale exponents to legacy multipliers.
* Modified the `_align_schema` function to:
  - Convert `OBS_VALUE` from units to "in scale" by dividing by the appropriate power of ten, matching the legacy behavior.
  - Convert `SCALE_CODE` from exponent to multiplier using the new mapping, ensuring compatibility with the old format.